### PR TITLE
fix: use grub as bootloader for SBCs

### DIFF
--- a/profiles/bananapi_m64/bananapi_m64.yaml
+++ b/profiles/bananapi_m64/bananapi_m64.yaml
@@ -7,3 +7,4 @@ output:
   imageOptions:
     diskSize: 1306525696
     diskFormat: raw
+    bootloader: grub

--- a/profiles/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.yaml
+++ b/profiles/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.yaml
@@ -7,3 +7,4 @@ output:
   imageOptions:
     diskSize: 1306525696
     diskFormat: raw
+    bootloader: grub

--- a/profiles/pine64/pine64.yaml
+++ b/profiles/pine64/pine64.yaml
@@ -7,3 +7,4 @@ output:
   imageOptions:
     diskSize: 1306525696
     diskFormat: raw
+    bootloader: grub


### PR DESCRIPTION
Part of: https://github.com/siderolabs/talos/issues/10859